### PR TITLE
b_bookstory: Update version of artifact in ci/cd pipeline script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           cd eth-analysis-ui && yarn test --ci --runInBand
           
       - name: Upload build artifacts (optional)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: react-build
           path: ./eth-analysis-ui/build


### PR DESCRIPTION
Fix issues caused by Github Action Plugin's version like: 

```
Current runner version: '2.321.0'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/[2](https://github.com/Rurutia1027/react-ts-projects/actions/runs/13055067925/job/36423981449#step:1:2)024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```